### PR TITLE
Run multiple worker group configs

### DIFF
--- a/lib/sneakers/spawner.rb
+++ b/lib/sneakers/spawner.rb
@@ -5,23 +5,30 @@ module Sneakers
   class Spawner
 
     def self.spawn
-      worker_group_config_file = ENV['WORKER_GROUP_CONFIG'] || "./config/sneaker_worker_groups.yml"
-      unless File.exists?(worker_group_config_file)
-        puts "No worker group file found."
-        puts "Specify via ENV 'WORKER_GROUP_CONFIG' or by convention ./config/sneaker_worker_groups.yml"
-        Kernel.exit(1)
-      end
+      raw_config_files = ENV['WORKER_GROUP_CONFIG'] || "./config/sneaker_worker_groups.yml"
+      worker_group_config_files = raw_config_files.split(';')
+
       @pids = []
       @exec_string = "bundle exec rake sneakers:run"
-      worker_config = YAML.load(ERB.new(File.read(worker_group_config_file)).result)
-      worker_config.keys.each do |group_name|
-        workers = worker_config[group_name]['classes']
-        workers = workers.join "," if workers.is_a?(Array)
-        @pids << fork do
-          @exec_hash = {"WORKERS"=> workers, "WORKER_COUNT" => worker_config[group_name]["workers"].to_s}
-          Kernel.exec(@exec_hash, @exec_string)
+
+      worker_group_config_files.each do |worker_group_config_file|
+        unless File.exists?(worker_group_config_file)
+          puts "No worker group file found."
+          puts "Specify via ENV 'WORKER_GROUP_CONFIG' or by convention ./config/sneaker_worker_groups.yml"
+          Kernel.exit(1)
+        end
+
+        worker_config = YAML.load(ERB.new(File.read(worker_group_config_file)).result)
+        worker_config.keys.each do |group_name|
+          workers = worker_config[group_name]['classes']
+          workers = workers.join "," if workers.is_a?(Array)
+          @pids << fork do
+            @exec_hash = {"WORKERS"=> workers, "WORKER_COUNT" => worker_config[group_name]["workers"].to_s}
+            Kernel.exec(@exec_hash, @exec_string)
+          end
         end
       end
+
       ["TERM", "USR1", "HUP", "USR2"].each do |signal|
         Signal.trap(signal){ @pids.each{|pid| Process.kill(signal, pid) } }
       end

--- a/lib/sneakers/spawner.rb
+++ b/lib/sneakers/spawner.rb
@@ -13,9 +13,9 @@ module Sneakers
 
       worker_group_config_files.each do |worker_group_config_file|
         unless File.exists?(worker_group_config_file)
-          puts "No worker group file found."
+          puts "#{worker_group_config_file} not found." 
           puts "Specify via ENV 'WORKER_GROUP_CONFIG' or by convention ./config/sneaker_worker_groups.yml"
-          Kernel.exit(1)
+          next
         end
 
         worker_config = YAML.load(ERB.new(File.read(worker_group_config_file)).result)


### PR DESCRIPTION
Add ability to handle multiple worker group configs for `Sneakers::Spawner`

You should be able to pass multiple config in `WORKER_GROUP_CONFIG` env var by separating config path with `;`

Example: 
```
WORKER_GROUP_CONFIG="./config/worker_group_1.yml;./config/worker_group_2.yml"
```